### PR TITLE
Update URL from -continuous to -snapshots

### DIFF
--- a/chromium-on-mac.sh
+++ b/chromium-on-mac.sh
@@ -7,8 +7,8 @@
 #
 SCRIPT_VERSION="1.32"
 
-CHROMIUM_URL="http://commondatastorage.googleapis.com/chromium-browser-continuous/index.html?path=Mac"
-CHROMIUM_URL2="http://commondatastorage.googleapis.com/chromium-browser-continuous/Mac"
+CHROMIUM_URL="http://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?path=Mac"
+CHROMIUM_URL2="http://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac"
 CHROMIUM_INSTALL_PATH="/Applications/"
 CHROMIUM_CURRENT_VERSION_FILE="$CHROMIUM_INSTALL_PATH/Chromium.app/Contents/Info.plist"
 #CHROMIUM_CURRENT_VERSION=`defaults read /Applications/Chromium.app/Contents/Info SVNRevision`


### PR DESCRIPTION
Hi!
I noticed last week that I was not getting Chromium versions beyond 340072 -- the script reported "No update available, you already have the latest version", which was true, because that is what was in `LAST_CHANGE`.

Did some poking around today and discovered that http://commondatastorage.googleapis.com/chromium-browser-continuous/ seems to have stopped at 340072, but /chromium-browser-snapshots/ behaves the same way and has the most recent version. So, a simple change.

Thanks for making this script! I use it every day. :+1: 
